### PR TITLE
Making 192nd color work

### DIFF
--- a/mgd3/metrics.ini
+++ b/mgd3/metrics.ini
@@ -133,6 +133,9 @@ ReverseDrawOrder=1101
 HoldHeadIsAboveWavyParts=1
 HoldTailIsAboveWavyParts=1
 HoldActiveIsAddLayer=0
+TapNoteNoteColorCount=9
+HoldHeadNoteColorCount=9
+RollHeadNoteColorCount=9
 
 
 #Edit this incase you want to make noteskin for reverse or both


### PR DESCRIPTION
I added 3 lines in the metrics to make the 192nds the correct color (gray) instead of appearing as 64ths (cyan).